### PR TITLE
tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,34 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
+branches:
+  except:
+    - gh-pages
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+  allow_failures:
+    - python: 3.6
+      env: TOXENV=py36
 
 install:
-  - pip install -r requirements.txt
-  - pip install -r requirements_tests.txt
+  - pip install tox
 
 script:
-  - pep8 storj
-  - coverage run --source="storj" setup.py test
+  - tox
 
 after_success:
+  - pip install coveralls
   - coveralls
 
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist =
+    py{36,35,34,33,27}
+    pypy
+
+
+[testenv]
+usedevelop = True
+deps =
+    -rrequirements.txt
+    -rrequirements_tests.txt
+    -rrequirements_develop.txt
+    wheel
+
+passenv = HOME LANG LC_ALL
+
+commands =
+	# auto pep8 code
+	autopep8 --in-place --aggressive --aggressive --recursive storj
+	autopep8 --in-place --aggressive --aggressive --recursive tests
+
+	# ensure pep8
+	pep8 storj
+	pep8 tests
+
+	# test
+	coverage run --source=storj setup.py test
+
+	# report coverage
+	coverage html
+	coverage report  # --fail-under=90


### PR DESCRIPTION
- use [tox](http://tox.readthedocs.io) to create virtualenvs and test code
- added python 3.5 classifier

with [tox](http://tox.readthedocs.io) parts of the Makefile don't make sense anymore but I'm leaving not to disrupt the way work is currently being done and let me people get used to this.

@frdwrd let me know what you think.
