### PR TITLE
+testing #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+t/
+tests/junit.xml
+
+# Created by https://www.gitignore.io/api/python,virtualenv
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
 
 # C extensions
 *.so
@@ -7,11 +15,13 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-bin/
 build/
 develop-eggs/
 dist/
+downloads/
 eggs/
+.eggs/
+lib/
 lib64/
 parts/
 sdist/
@@ -19,7 +29,12 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-test.py
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
@@ -29,44 +44,67 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
+*,cover
+.hypothesis/
 
 # Translations
 *.mo
-
-# OS X
-*.DS_Store
-
-# Vagrant
-.vagrant/
-*.box
-
-# Redis
-dump.rdb
-
-# PyCharm
-.idea/
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
+*.pot
 
 # Django stuff:
 *.log
-*.pot
-streisand/db.sqlite3
-streisand/static/
-/torrents/
+local_settings.py
 
-# Sockets
-*.sock
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
-*.pyc
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+
+### VirtualEnv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,3 +1,6 @@
-coverage
-coveralls
-pep8
+mock
+pylint
+pytest
+pytest-cov
+pytest-pep8
+pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import pip.download
+
+from pip.req import parse_requirements
+
 
 from setuptools import setup, find_packages
 
@@ -10,21 +14,28 @@ exec(open('storj/version.py').read())  # load __version__
 
 setup(
     name='storj',
+    version=__version__,  # NOQA
     description='A Python SDK for the Storj API',
-    long_description=open("README.rst").read(),
-    keywords='storj, bridge, metadisk, api, client, sdk, python',
+    long_description=open('README.rst').read(),
     url='http://storj.io',
     author='Daniel Hawkins',
     author_email='hwkns@alum.mit.edu',
     license='MIT',
-    version=__version__,  # NOQA
-    test_suite="tests",
     dependency_links=[],
     # package_data={'storj': ['data/*.json']},
     # include_package_data=True,
-    install_requires=open("requirements.txt").readlines(),
-    tests_require=open("requirements_tests.txt").readlines(),
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=('*.tests', '*.tests.*', 'tests.*', 'tests')
+    ),
+    install_requires=[
+        str(pkg.req) for pkg in parse_requirements(
+            'requirements.txt', session=pip.download.PipSession())
+    ],
+    test_suite='tests',
+    tests_require=[
+        str(pkg.req) for pkg in parse_requirements(
+            'requirements_tests.txt', session=pip.download.PipSession())
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -41,4 +52,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
     ],
+    keywords=','.join([
+        'storj', 'bridge', 'metadisk', 'api', 'client', 'sdk', 'python'
+    ]),
 )

--- a/storj/__init__.py
+++ b/storj/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Storj package."""
 
 from hashlib import sha256
 
@@ -17,14 +18,17 @@ register_new_user = api_client.register_user
 
 
 def generate_new_key_pair():
+    """
+    Generate a new key pair.
 
-    # Private key
-    signing_key = SigningKey.generate(
+    Returns:
+        tuple(:py:class:`ecdsa.keys.SigningKey`, `ecdsa.keys.VerifyingKey`):
+        key pair (private, public).
+    """
+
+    private_key = SigningKey.generate(
         curve=SECP256k1,
         hashfunc=sha256,
     )
 
-    # Public key
-    verifying_key = signing_key.get_verifying_key()
-
-    return signing_key, verifying_key
+    return private_key, private_key.get_verifying_key()

--- a/storj/api.py
+++ b/storj/api.py
@@ -38,12 +38,15 @@ def ecdsa_to_hex(ecdsa_key):
     Return hexadecimal string representation of the ECDSA key.
 
     Args:
-        ecdsa_key: ECDSA key.
+        ecdsa_key (bytes): ECDSA key.
+
+    Raises:
+        TypeError: if the ECDSA key is not an array of bytes.
 
     Returns:
         str: hexadecimal string representation of the ECDSA key.
     """
-    return '04' + b2a_hex(ecdsa_key).decode('ascii')
+    return '04%s' % b2a_hex(ecdsa_key).decode('ascii')
 
 
 class MetadiskApiError(Exception):

--- a/storj/api.py
+++ b/storj/api.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+"""Storj API module."""
+
 from __future__ import unicode_literals
 
 import os
 import time
 import json
+
 from binascii import b2a_hex
 from base64 import b64encode
 from hashlib import sha256
@@ -23,6 +26,7 @@ except ImportError:
     from urlparse import urljoin
 
 import requests
+
 from requests import Request
 from ecdsa import SigningKey
 from ecdsa.util import sigencode_der
@@ -30,6 +34,15 @@ from ws4py.client.threadedclient import WebSocketClient
 
 
 def ecdsa_to_hex(ecdsa_key):
+    """
+    Return hexadecimal string representation of the ECDSA key.
+
+    Args:
+        ecdsa_key: ECDSA key.
+
+    Returns:
+        str: hexadecimal string representation of the ECDSA key.
+    """
     return '04' + b2a_hex(ecdsa_key).decode('ascii')
 
 

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from storj import api
+
+
+class ModuleTestCase(unittest.TestCase):
+
+    def test_ecdsa_to_hex(self):
+        key = '\xf8\xd25-\xaf\xa1G\xdb\xa0\xee\xfd\xf9c\x01\xcf\x0cr' \
+              '\xcb\xf5\xb6\x1e\xea\xa1FeJ\x0f\x9bv\xc2\xba{\xa83\xdb\\' \
+              '\x1a\xb5\x0c\x1a\xd3\xf4\xdb3\xb6.\x95g'
+
+        expected = '04f8d2352dafa147dba0eefdf96301cf0c72cbf5b61eeaa14665' \
+                   '4a0f9b76c2ba7ba833db5c1ab50c1ad3f4db33b62e9567'
+
+        self.assertEqual(expected, api.ecdsa_to_hex(key))

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
+"""Test cases for the storj.api module."""
 
 import unittest
 
 from storj import api
 
 
-class ModuleTestCase(unittest.TestCase):
+class FunctionsTestCase(unittest.TestCase):
+    """Test case for the module functions."""
 
     def test_ecdsa_to_hex(self):
-        key = '\xf8\xd25-\xaf\xa1G\xdb\xa0\xee\xfd\xf9c\x01\xcf\x0cr' \
-              '\xcb\xf5\xb6\x1e\xea\xa1FeJ\x0f\x9bv\xc2\xba{\xa83\xdb\\' \
-              '\x1a\xb5\x0c\x1a\xd3\xf4\xdb3\xb6.\x95g'
+        """Test ecdsa_to_hex()."""
 
-        expected = '04f8d2352dafa147dba0eefdf96301cf0c72cbf5b61eeaa14665' \
-                   '4a0f9b76c2ba7ba833db5c1ab50c1ad3f4db33b62e9567'
+        key = b'\xf8\xd2\xaf\xa1\xdb\xa0\xee\xfd\xf9c\x01\xcf\x0c'
 
-        self.assertEqual(expected, api.ecdsa_to_hex(key))
+        self.assertEqual('04f8d2afa1dba0eefdf96301cf0c', api.ecdsa_to_hex(key))

--- a/tests/unit/storj_test.py
+++ b/tests/unit/storj_test.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Test cases for the storj package."""
+
+import storj
+import unittest
+
+from ecdsa import keys
+
+
+class FunctionsTestCase(unittest.TestCase):
+    """Test case for the package functions."""
+
+    def test_generate_new_key_pair(self):
+        """Test generate_new_key_pair()."""
+
+        key, key_pub = storj.generate_new_key_pair()
+
+        self.assertIsNotNone(key)
+        self.assertIsNotNone(key_pub)
+
+        self.assertTrue(isinstance(key, keys.SigningKey))
+        self.assertTrue(isinstance(key_pub, keys.VerifyingKey))
+
+        self.assertEqual(key_pub, key.get_verifying_key())
+        self.assertEqual(32, len(key.to_string()))

--- a/tox.ini
+++ b/tox.ini
@@ -4,28 +4,26 @@ envlist =
     pypy
 
 
+[pytest]
+pep8maxlinelength = 119
+norecursedirs = .git .tox env coverage docs
+pep8ignore =
+    docs/conf.py ALL
+
+
 [testenv]
 usedevelop = True
 deps =
     -rrequirements.txt
     -rrequirements_tests.txt
-    -rrequirements_develop.txt
-    wheel
 
-passenv = HOME LANG LC_ALL
+passenv = HOME LANG LC_ALL USER
 
 commands =
-	# auto pep8 code
-	autopep8 --in-place --aggressive --aggressive --recursive storj
-	autopep8 --in-place --aggressive --aggressive --recursive tests
-
-	# ensure pep8
-	pep8 storj
-	pep8 tests
-
-	# test
-	coverage run --source=storj setup.py test
-
-	# report coverage
-	coverage html
-	coverage report  # --fail-under=90
+    py.test -q --basetemp={envtmpdir} --confcutdir=.. -n 1 \
+        --junitxml=tests/junit.xml \
+        --cov-report xml --cov storj \
+        --cov-report=html \
+        --cov-report term-missing \
+        --pep8 \
+        {posargs}


### PR DESCRIPTION
- changed testing to be done with `pytest` commands instead (one command can do all: run unit tests, code style and code coverate)
- `storj` package now covered 100%
- +1 test for `api.ecdsa_to_hex` function
- current test coverage will raise to 39%
- updated `.gitignore` rules

to run these new tests do:
```
$ pip install tox
$ tox -e py27
```