### PR TITLE
Pep8 Compliance

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # html_logo = os.path.join('_static', 'logo.png')
 
 # The name of an image file (relative to this directory) to use as a favicon of
-# the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# the docs. This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #
 # html_favicon = None
@@ -262,21 +262,21 @@ htmlhelp_basename = 'py_storj'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files.
@@ -367,7 +367,7 @@ texinfo_documents = [(
     master_doc,
     'py_storj',
     'Storj documentation',
-     author,
+    author,
     '',
     'Storj documentation.',
     'Miscellaneous'

--- a/storj/__init__.py
+++ b/storj/__init__.py
@@ -12,7 +12,8 @@ def generate_new_key_pair():
     Generate a new key pair.
 
     Returns:
-        tuple(:py:class:`ecdsa.keys.SigningKey`, :py:class:`ecdsa.keys.VerifyingKey`):
+        tuple(:py:class:`ecdsa.keys.SigningKey`,
+              :py:class:`ecdsa.keys.VerifyingKey`):
         key pair (private, public).
     """
 

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -68,8 +68,9 @@ def bucket():
 
 
 @bucket.command()
-@click.option('--storage', default=None, help='Storage limit.', type=click.INT)
-@click.option('--transfer', default=None, help='Transfer limit', type=click.INT)
+@click.option('--storage', default=None, help='Storage limit', type=click.INT)
+@click.option('--transfer', default=None,
+              help='Transfer limit', type=click.INT)
 @click.argument('name', type=click.STRING)
 def create(storage, transfer, name):
     """Create bucket.

--- a/storj/http.py
+++ b/storj/http.py
@@ -94,16 +94,17 @@ class Client(object):
 
         contract = '\n'.join(
             (method, request_kwargs['path'], data)).encode('utf-8')
+
         signature_bytes = self.private_key.sign(
             contract, sigencode=sigencode_der, hashfunc=sha256)
+
         signature = b2a_hex(signature_bytes).decode('ascii')
 
         request_kwargs['headers'].update(
             {
                 'x-signature': signature,
                 'x-pubkey': ecdsa_to_hex(self.public_key),
-            }
-        )
+            })
 
     def _prepare_request(self, **kwargs):
 
@@ -187,8 +188,7 @@ class Client(object):
             path='/buckets/%s/files/%s' % (bucket_id, file_hash),
             headers={
                 'x-token': pull_token['token'],
-            }
-        )
+            })
 
     def bucket_get(self, bucket_id):
         """Returns buckets.
@@ -200,8 +200,11 @@ class Client(object):
             (:py:class:`model.Bucket`): bucket.
         """
         try:
-            response = self._request(method='GET', path='/buckets/%s' % bucket_id)
+            response = self._request(
+                method='GET',
+                path='/buckets/%s' % bucket_id)
             return model.Bucket(**response)
+
         except requests.HTTPError as e:
             if e.response.status_code == requests.codes.not_found:
                 return None
@@ -226,7 +229,10 @@ class Client(object):
             raise StopIteration
 
     def bucket_set_keys(self, bucket_id, keys):
-        self._request(method='PATCH', path='/buckets/%s' % bucket_id, json={'pubkeys': keys})
+        self._request(
+            method='PATCH',
+            path='/buckets/%s' % bucket_id,
+            json={'pubkeys': keys})
 
     def contacts_list(self):
         response = self._request(method='GET', path='/contacts', json={})
@@ -249,7 +255,9 @@ class Client(object):
         return file_contents
 
     def file_get(self, bucket_id):
-        response = self._request(method='GET', path='/buckets/%s/files' % bucket_id)
+        response = self._request(
+            method='GET',
+            path='/buckets/%s/files' % bucket_id)
 
         if response is None:
             return response
@@ -283,14 +291,14 @@ class Client(object):
         # delete encrypted file
         self._request(
             method='POST', path='/buckets/%s/files' % bucket_id,
-            #files={'file' : file},
+            # files={'file' : file},
             headers={
-            #    'x-token': push_token['token'],
-            #    'x-filesize': str(file_size)}
-            "frame": frame['id'],
-            "mimetype": "text",
-            "filename": file.name,
-        })
+                #    'x-token': push_token['token'],
+                #    'x-filesize': str(file_size)}
+                "frame": frame['id'],
+                "mimetype": "text",
+                "filename": file.name,
+            })
 
     def file_remove(self, bucket_id, file_id):
         """Delete a file pointer from a specified bucket
@@ -302,8 +310,7 @@ class Client(object):
 
         self._request(
             method='DELETE',
-            path='/buckets/%s/files/%s' % (bucket_id, file_id)
-        )
+            path='/buckets/%s/files/%s' % (bucket_id, file_id))
 
     def frame_add_shard(self, shard, frame_id):
         data = {
@@ -315,10 +322,9 @@ class Client(object):
         }
 
         response = self._request(
-        method='PUT',
-        path='/frames/%s' % frame_id,
-        json=data
-        )
+            method='PUT',
+            path='/frames/%s' % frame_id,
+            json=data)
 
         if response is not None:
             return response
@@ -326,7 +332,9 @@ class Client(object):
     def frame_create(self):
         """Create a file staging frame.
 
-        See `API frames:Creates a new file staging frame<https://storj.io/api.html#staging>`_
+        See `API frames:
+        Creates a new file staging frame
+        <https://storj.io/api.html#staging>`
 
         Returns:
 
@@ -342,13 +350,14 @@ class Client(object):
         self._request(
             method='DELETE',
             path='/frames/%s' % frame_id,
-            json={'frame_id': frame_id}
-        )
+            json={'frame_id': frame_id})
 
     def frame_get(self, frame_id):
         """Return a frame.
 
-        See `API frame: Fetches the file staging frame by it's unique ID<https://storj.io/api.html>`_
+        See `API frame:
+        Fetches the file staging frame by it's unique ID
+        <https://storj.io/api.html>`_
 
         Args:
             frame_id (str): unique identifier.
@@ -356,7 +365,10 @@ class Client(object):
         Returns:
             (?):
         """
-        response = self._request(method='GET', path='/frames/%s' % frame_id, json={'frame_id': frame_id})
+        response = self._request(
+            method='GET',
+            path='/frames/%s' % frame_id,
+            json={'frame_id': frame_id})
 
         if response is not None:
             return model.Frame(**response)
@@ -367,7 +379,10 @@ class Client(object):
         Returns:
             (): all open file staging frames.
         """
-        response = self._request(method='GET', path='/frames', json={})
+        response = self._request(
+            method='GET',
+            path='/frames',
+            json={})
 
         if response is not None:
             return response
@@ -377,10 +392,12 @@ class Client(object):
 
     def key_dump(self):
         if (self.private_key is not None and self.public_key is not None):
-            print("Local Private Key: " + self.private_key +
-                  "Local Public Key:" + self.public_key)
+            print("Local Private Key: "
+                  + self.private_key
+                  + "Local Public Key:" + self.public_key)
         if (self.key_get() is not []):
-            print("Public keys for this account: " + str([key['id'] for key in self.key_get()]))
+            print("Public keys for this account: "
+                  + str([key['id'] for key in self.key_get()]))
         else:
             print("No keys associated with this account.")
 
@@ -422,7 +439,10 @@ class Client(object):
         self.key_register(self.public_key)
 
     def key_register(self, public_key):
-        response = self._request(method='POST', path='/keys', json={'key': ecdsa_to_hex(public_key)})
+        response = self._request(
+            method='POST',
+            path='/keys',
+            json={'key': ecdsa_to_hex(public_key)})
 
         if response is not None:
             return response
@@ -438,12 +458,18 @@ class Client(object):
             (dict[]):
         """
         self.logger.debug('create_token(%s, %s)', bucket_id, operation)
-        return self._request(method='POST', path='/buckets/%s/tokens' % bucket_id, json={'operation': operation})
+        return self._request(
+            method='POST',
+            path='/buckets/%s/tokens' % bucket_id,
+            json={'operation': operation})
 
     def user_create(self, email, password):
 
         password = sha256(password).hexdigest()
 
-        self._request(method='POST', path='/users', json={'email': email, 'password': password})
+        self._request(
+            method='POST',
+            path='/users',
+            json={'email': email, 'password': password})
 
         self.authenticate(email=email, password=password)

--- a/storj/metadata.py
+++ b/storj/metadata.py
@@ -2,5 +2,5 @@
 """Storj metadata module."""
 
 __author__ = 'Daniel Hawkins,Fabian Barkhau,Mike Bailey,Pedro Salgado,James Prestwich'
-__author_email__ = 'hwkns@alum.mit.edu;f483@storj.io;mibgranny@aol.com;steenzout@ymail.com'
+__author_email__ = 'hwkns@alum.mit.edu;f483@storj.io;mibgranny@aol.com;steenzout@ymail.com;james@storj.io'
 __version__ = '0.1.5'

--- a/storj/model.py
+++ b/storj/model.py
@@ -211,12 +211,11 @@ class Shard:
             self.exclude = []
 
     def all(self):
-        return 'Shard{index=%s, hash=%s, size=%s, tree={%s}, challenges={%s}' %
-        (
-            self.index, self.hash, self.size,
+        return 'Shard{index=%s, hash=%s, size=%s, tree={%s}, challenges={%s}' % (
+            self.index,
+            self.hash, self.size,
             ', '.join(self.tree),
-            ', '.join(self.challenges)
-        )
+            ', '.join(self.challenges))
 
     def add_challenge(self, challenge):
         """Append challenge.

--- a/storj/model.py
+++ b/storj/model.py
@@ -16,7 +16,8 @@ from steenzout.object import Object
 class Bucket(Object):
     """Storage bucket.
 
-    A bucket is a logical grouping of files which the user can assign permissions and limits to.
+    A bucket is a logical grouping of files
+    which the user can assign permissions and limits to.
 
     Attributes:
         id (str): unique identifier.
@@ -46,7 +47,8 @@ class Bucket(Object):
         # self.tokens = TokenManager(bucket_id=self.id)
 
         if created is not None:
-            self.created = datetime.fromtimestamp(strict_rfc3339.rfc3339_to_timestamp(created))
+            self.created = datetime.fromtimestamp(
+                strict_rfc3339.rfc3339_to_timestamp(created))
         else:
             self.created = None
 
@@ -68,7 +70,8 @@ class File(Object):
         shardManager ():
     """
 
-    def __init__(self, bucket=None, hash=None, mimetype=None, filename=None, size=None, id=None):
+    def __init__(self, bucket=None, hash=None, mimetype=None,
+                 filename=None, size=None, id=None):
         self.bucket = Bucket(id=bucket)
         self.hash = hash
         self.mimetype = mimetype
@@ -93,7 +96,8 @@ class File(Object):
             name=self.filename, size=self.size, content_type=self.mimetype)
 
     def download(self):
-        return api_client.file_download(bucket_id=self.bucket, file_hash=self.hash)
+        return api_client.file_download(bucket_id=self.bucket,
+                                        file_hash=self.hash)
 
     def delete(self):
         bucket_files = FileManager(bucket_id=self.bucket)
@@ -113,7 +117,8 @@ class Frame(Object):
         self.id = id
 
         if created is not None:
-            self.created = datetime.fromtimestamp(strict_rfc3339.rfc3339_to_timestamp(created))
+            self.created = datetime.fromtimestamp(
+                strict_rfc3339.rfc3339_to_timestamp(created))
         else:
             self.created = None
 
@@ -131,8 +136,8 @@ class Keyring:
 
     def generate(self):
         user_pass = raw_input("Enter your keyring password: ")
-        password = hex(random.getrandbits(512*8))[2:-1]
-        salt = hex(random.getrandbits(32*8))[2:-1]
+        password = hex(random.getrandbits(512 * 8))[2:-1]
+        salt = hex(random.getrandbits(32 * 8))[2:-1]
 
         pbkdf2 = hashlib.pbkdf2_hmac('sha512', password, salt, 25000, 512)
 
@@ -143,8 +148,9 @@ class Keyring:
         self.salt = salt
 
     def export_keyring(self, password, salt, user_pass):
-        plain = pad("{\"pass\" : \"%s\", \n\"salt\" : \"%s\"\n}" % (password, salt))
-        IV = hex(random.getrandbits(8*8))[2:-1]
+        plain = pad("{\"pass\" : \"%s\", \n\"salt\" : \"%s\"\n}"
+                    % (password, salt))
+        IV = hex(random.getrandbits(8 * 8))[2:-1]
 
         aes = AES.new(pad(user_pass), AES.MODE_CBC, IV)
 
@@ -181,7 +187,8 @@ class Shard:
         exclude (list[str]):
     """
 
-    def __init__(self, id=None, hash=None, index=None, challenges=None, tree=None, exclude=None):
+    def __init__(self, id=None, hash=None, index=None,
+                 challenges=None, tree=None, exclude=None):
         self.id = None
         # self.path = None
         self.hash = None
@@ -204,7 +211,8 @@ class Shard:
             self.exclude = []
 
     def all(self):
-        return 'Shard{index=%s, hash=%s, size=%s, tree={%s}, challenges={%s}' % (
+        return 'Shard{index=%s, hash=%s, size=%s, tree={%s}, challenges={%s}' %
+        (
             self.index, self.hash, self.size,
             ', '.join(self.tree),
             ', '.join(self.challenges)
@@ -239,7 +247,7 @@ class ShardManager:
             chunk = file.read(shard_size)
             if not chunk:
                 break
-            tmpfile = open("C:/test/shard"+str(self.index)+".shard", "wb")
+            tmpfile = open("C:/test/shard" + str(self.index) + ".shard", "wb")
             tmpfile.write(chunk)
             tmpfile.close()
 
@@ -255,7 +263,8 @@ class ShardManager:
         for i in xrange(numberOfChallenges):
             challenge = self.getRandomChallengeString()
 
-            data2hash = binascii.hexlify('%s%s' % (challenge, shardData))  # concat and hex-encode data
+            # concat and hex-encode data
+            data2hash = binascii.hexlify('%s%s' % (challenge, shardData))
 
             tree = hash160(hash160(data2hash))  # double hash160 the data
 
@@ -263,7 +272,8 @@ class ShardManager:
             shard.add_tree(tree)
 
             def getRandomChallengeString(self):
-                    return ''.join(random.choice(string.ascii_letters) for _ in xrange(32))
+                return ''.join(
+                    random.choice(string.ascii_letters) for _ in xrange(32))
 
 
 class Token(Object):
@@ -283,7 +293,8 @@ class Token(Object):
         self.operation = operation
 
         if expires is not None:
-            self.expires = datetime.strptime(expires, '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=utc)
+            self.expires = datetime.strptime(
+                expires, '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=utc)
         else:
             self.expires = None
 

--- a/storj/sdk.py
+++ b/storj/sdk.py
@@ -123,7 +123,8 @@ class FileManager:
         return [File(payload) for payload in files_json]
 
     def _upload(self, file, frame):
-        api_client.file_upload(bucket_id=self.bucket_id, file=file, frame=frame)
+        api_client.file_upload(bucket_id=self.bucket_id,
+                               file=file, frame=frame)
 
     def upload(self, file, frame):
 
@@ -158,4 +159,4 @@ def pad(s):
 
 
 def unpad(s):
-    return s[:-ord(s[len(s)-1:])]
+    return s[:-ord(s[len(s) - 1:])]

--- a/storj/web_socket.py
+++ b/storj/web_socket.py
@@ -10,7 +10,8 @@ class Client(WebSocketClient):
 
     def __init__(self, pointer, file_contents):
         assert isinstance(pointer, dict)
-        URI = "ws://" + pointer.get('farmer')['address'] + ":" + str(pointer.get('farmer')['port'])
+        URI = "ws://" + pointer.get('farmer')['address']
+        URI += ":" + str(pointer.get('farmer')['port'])
         self.json = pointer
         self.file_contents = file_contents
         super(Client, self).__init__(URI)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,7 +29,8 @@ class Basic(object):
         Setup test configuration.
         It will also load (once) the test configuration.
         """
-        logging.getLogger('%s.%s' % (__name__, 'Basic')).info('setup_configuration()')
+        logging.getLogger(
+            '%s.%s' % (__name__, 'Basic')).info('setup_configuration()')
 
         self.configuration = config.get()
 
@@ -40,7 +41,8 @@ class Basic(object):
         """
         logging.getLogger('%s.%s' % (__name__, 'Basic')).info('setup_logger()')
 
-        self.logger = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
+        self.logger = logging.getLogger(
+            '%s.%s' % (__name__, self.__class__.__name__))
 
 
 class AbstractTestCase(unittest.TestCase, Basic):

--- a/tests/config.py
+++ b/tests/config.py
@@ -42,11 +42,13 @@ def load_configuration(config_file=DEFAULT_CONFIG_FILE):
         Cache.settings = {}
         for section in parser.sections():
             Cache.settings[section] = dict(parser.items(section))
-        logging.getLogger(__name__).info('%s configuration file was loaded.', config_file)
+        logging.getLogger(__name__).info(
+            '%s configuration file was loaded.', config_file)
         return Cache.settings
     except Exception as e:
         Cache.settings = None
-        logging.getLogger(__name__).error('Failed to load configuration from %s!', config_file)
+        logging.getLogger(__name__).error(
+            'Failed to load configuration from %s!', config_file)
         logging.getLogger(__name__).debug(str(e), exc_info=True)
         raise e
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -34,7 +34,7 @@ class Integration(AbstractTestCase):
         except KeyError as e:
             self.logger.error(e)
             err_msg = 'To run integration tests you need to define the following environment variables: %s, %s.' % (
-                    ENV_STORJ_EMAIL, ENV_STORJ_PASSWORD)
+                ENV_STORJ_EMAIL, ENV_STORJ_PASSWORD)
             self.logger.error(err_msg)
             self.fail(err_msg)
 

--- a/tests/integration/bucket_test.py
+++ b/tests/integration/bucket_test.py
@@ -17,7 +17,8 @@ class Bucket(Integration):
     def setUp(self):
         """Setup test bucket."""
         super(Bucket, self).setUp()
-        self.bucket = self.client.bucket_create('integration-%s' % self.test_id)
+        self.bucket = self.client.bucket_create(
+            'integration-%s' % self.test_id)
 
     def tearDown(self):
         """Destroy test bucket."""

--- a/tests/integration/bucket_test.py
+++ b/tests/integration/bucket_test.py
@@ -5,6 +5,7 @@ import pytest
 
 
 from . import Integration
+from requests.exceptions import HTTPError
 
 
 class Bucket(Integration):
@@ -23,7 +24,10 @@ class Bucket(Integration):
     def tearDown(self):
         """Destroy test bucket."""
         super(Bucket, self).tearDown()
-        self.client.bucket_delete(self.bucket.id)
+        try:
+            self.client.bucket_delete(self.bucket.id)
+        except HTTPError:
+            pass
 
     def test(self):
         """Test:

--- a/tests/log_config.py
+++ b/tests/log_config.py
@@ -15,7 +15,8 @@ def load_configuration(config_file=DEFAULT_CONFIG_FILE):
     """
     Loads logging configuration from the given configuration file.
 
-    :param config_file: the configuration file (default=/etc/package/logging.conf)
+    :param config_file:
+        the configuration file (default=/etc/package/logging.conf)
     :type config_file: str
     """
     if not os.path.exists(config_file) or not os.path.isfile(config_file):
@@ -25,8 +26,10 @@ def load_configuration(config_file=DEFAULT_CONFIG_FILE):
 
     try:
         config.fileConfig(config_file, disable_existing_loggers=False)
-        logging.getLogger(__name__).info('%s configuration file was loaded.', config_file)
+        logging.getLogger(__name__).info(
+            '%s configuration file was loaded.', config_file)
     except Exception as e:
-        logging.getLogger(__name__).error('Failed to load configuration from %s!', config_file)
+        logging.getLogger(__name__).error(
+            'Failed to load configuration from %s!', config_file)
         logging.getLogger(__name__).debug(str(e), exc_info=True)
         raise e

--- a/tests/unit/http_test.py
+++ b/tests/unit/http_test.py
@@ -18,7 +18,8 @@ class ClientTestCase(AbstractTestCase):
         self.email = 'email@example.com'
         self.password = 's3CR3cy'
         self.client = http.Client(self.email, self.password)
-        self.password_digest = sha256(self.password.encode('ascii')).hexdigest()
+        self.password_digest = sha256(
+            self.password.encode('ascii')).hexdigest()
 
     def test_init(self):
         """Test Client.__init__()."""

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ pep8maxlinelength = 119
 norecursedirs = .git .tox env coverage docs
 pep8ignore =
     docs/conf.py ALL
+    *.py W503
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 pep8maxlinelength = 119
 norecursedirs = .git .tox env coverage docs
 pep8ignore =
-    docs/conf.py ALL
+    docs/conf.py E402
     *.py W503
 
 


### PR DESCRIPTION
I made my pep8 linter stop yelling at me. Tried to make styling consistent across files, and err on the side of not making changes.

Some comments are still too long. I wasn't sure how to address those, and I don't know that I was consistent.

I left a few warnings in docs/conf.py related to this line: `sys.path.insert(0, os.path.abspath('..'))` The warnings were `E402 module level import not at top of file`. I was unsure whether modifying the path affected those imports.