### PR TITLE
wrap 3rd party exceptions in an API error + frdwrd changes

### DIFF
--- a/storj/http.py
+++ b/storj/http.py
@@ -55,7 +55,7 @@ class Client(object):
 
     @property
     def password(self):
-        """(str):"""
+        """(str): user password"""
         return self._password
 
     @password.setter

--- a/storj/http.py
+++ b/storj/http.py
@@ -128,6 +128,12 @@ class Client(object):
 
         Args:
             kwargs (dict): keyword arguments.
+
+        Raises:
+            :py:class:`MetadiskApiError`: in case::
+                - internal server error
+                - error attribute is present in the JSON response
+                - HTTP response JSON decoding failed
         """
 
         response = self.session.send(self._prepare_request(**kwargs))
@@ -138,7 +144,7 @@ class Client(object):
         except requests.exceptions.HTTPError as e:
             self.logger.error(e)
             self.logger.debug('response.text=%s', response.text)
-            raise e
+            raise MetadiskApiError(response.text)
 
         # Raise any errors as exceptions
         try:
@@ -153,9 +159,9 @@ class Client(object):
             return response_json
 
         except JSONDecodeError as e:
-            self.logger.error('_request %s', e)
+            self.logger.error(e)
             self.logger.error('_request body %s', response.text)
-            raise e
+            raise MetadiskApiError('Could not decode response.')
 
     def bucket_create(self, name, storage=None, transfer=None):
         """Create storage bucket.

--- a/storj/model.py
+++ b/storj/model.py
@@ -24,7 +24,8 @@ class Bucket(Object):
         name (str): name.
         status (str): bucket status (Active, ...).
         user (str): user email address.
-        created (:py:class:`datetime.datetime`): time when the bucket was created.
+        created (:py:class:`datetime.datetime`):
+            time when the bucket was created.
         storage (int): storage limit (in GB).
         transfer (int): transfer limit (in GB).
         pubkeys ():
@@ -109,7 +110,8 @@ class Frame(Object):
 
     Attributes:
         id (str): unique identifier.
-        created (:py:class:`datetime.datetime`): time when the bucket was created.
+        created (:py:class:`datetime.datetime`):
+            time when the bucket was created.
         shards (list[:py:class:`Shard`]): shards that compose this frame.
     """
 

--- a/tests/integration/bucket_test.py
+++ b/tests/integration/bucket_test.py
@@ -56,4 +56,4 @@ class Bucket(Integration):
 
         self.logger.debug('%s 2.2' % __name__)
         with pytest.raises(StopIteration):
-            self.client.bucket_list().next()
+            next(self.client.bucket_list())

--- a/tests/unit/http_test.py
+++ b/tests/unit/http_test.py
@@ -5,8 +5,8 @@ from .. import AbstractTestCase
 
 from hashlib import sha256
 
-
 from storj import http
+from storj import model
 
 
 class ClientTestCase(AbstractTestCase):
@@ -37,7 +37,10 @@ class ClientTestCase(AbstractTestCase):
 
     def test_bucket_create(self):
         """Test Client.bucket_create()."""
-        pass
+        bucket = self.client.bucket_create("Test Bucket",
+                                           storage=25, transfer=39)
+
+        assert isinstance(bucket, model.Bucket)
 
     def test_bucket_delete(self):
         """Test Client.bucket_delete()."""

--- a/tests/unit/http_test.py
+++ b/tests/unit/http_test.py
@@ -2,11 +2,11 @@
 """Test cases for the storj.http module."""
 
 from .. import AbstractTestCase
+import mock
 
 from hashlib import sha256
 
 from storj import http
-from storj import model
 
 
 class ClientTestCase(AbstractTestCase):
@@ -18,6 +18,7 @@ class ClientTestCase(AbstractTestCase):
         self.email = 'email@example.com'
         self.password = 's3CR3cy'
         self.client = http.Client(self.email, self.password)
+        self.client._request = mock.MagicMock()
         self.password_digest = sha256(
             self.password.encode('ascii')).hexdigest()
 
@@ -37,10 +38,13 @@ class ClientTestCase(AbstractTestCase):
 
     def test_bucket_create(self):
         """Test Client.bucket_create()."""
-        bucket = self.client.bucket_create("Test Bucket",
+        test_name = 'Test Bucket'
+        bucket = self.client.bucket_create(test_name,
                                            storage=25, transfer=39)
+        test_json = {'name': test_name, 'storage': 25, 'transfer': 39}
 
-        assert isinstance(bucket, model.Bucket)
+        self.client._request.assert_called_with(method='POST', path='/buckets',
+                                                json=test_json)
 
     def test_bucket_delete(self):
         """Test Client.bucket_delete()."""

--- a/tests/unit/http_test.py
+++ b/tests/unit/http_test.py
@@ -7,6 +7,7 @@ import mock
 from hashlib import sha256
 
 from storj import http
+from storj import model
 
 
 class ClientTestCase(AbstractTestCase):
@@ -38,13 +39,15 @@ class ClientTestCase(AbstractTestCase):
 
     def test_bucket_create(self):
         """Test Client.bucket_create()."""
-        test_name = 'Test Bucket'
-        bucket = self.client.bucket_create(test_name,
-                                           storage=25, transfer=39)
-        test_json = {'name': test_name, 'storage': 25, 'transfer': 39}
+        test_json = {'name': 'Test Bucket', 'storage': 25, 'transfer': 39}
+        self.client._request.return_value = test_json
+
+        bucket = self.client.bucket_create('Test Bucket', storage=25,
+                                           transfer=39)
 
         self.client._request.assert_called_with(method='POST', path='/buckets',
                                                 json=test_json)
+        self.assertIsInstance(bucket, model.Bucket)
 
     def test_bucket_delete(self):
         """Test Client.bucket_delete()."""


### PR DESCRIPTION
- from @frdwrd
  - Python 3 compatibility change
  - comment change
  - added unit test for `bucket_create`

- extra
  - fixed logger names
  - HTTP client no longer returns `requests.exceptions.*` but it will now wrap all errors into a `storj.exceptions.*` class (for now we only have `MetadiskApiError` so I only added that one)
  - added new logging statements to be easy to track what calls are being made in the `log/storj-dev.log` file


@super3 @Miskerest @frdwrd please review.