### PR TITLE
tests for `storj.cli`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ecdsa>=0.13
 pycrypto>=2.6.1
 pytz>=2016.2
 requests>=2.7.0
+six>=1.10.0
 steenzout.object>=1.0.8
 steenzout.serialization.json>=1.0.2
 strict_rfc3339>=0.7

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -5,7 +5,6 @@ import os
 import click
 import ConfigParser
 
-# from storj.api import generate_new_key_pair, export_key, import_key
 from storj.http import Client
 
 

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -89,7 +89,7 @@ def get(bucket_id):
     """Get bucket."""
     bucket = get_client().bucket_get(bucket_id)
 
-    for attr, value in bucket.__dict__.iteritems():
+    for attr, value in sorted(bucket.__dict__.items()):
         click.echo('%s : %s' % (attr.rjust(8), value))
 
 

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -2,10 +2,11 @@
 """Storj command-line interface package."""
 
 import os
-import ConfigParser
 import logging
 
 import click
+
+from six.moves import configparser
 
 from storj.http import Client
 
@@ -35,7 +36,7 @@ def read_config():
     # OSX: /Users/<username>/Library/Application Support/storj
     cfg = os.path.join(click.get_app_dir(APP_NAME), 'storj.ini')
 
-    parser = ConfigParser.RawConfigParser()
+    parser = configparser.RawConfigParser()
     parser.read([cfg])
 
     rv = {}

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -2,8 +2,10 @@
 """Storj command-line interface package."""
 
 import os
-import click
 import ConfigParser
+import logging
+
+import click
 
 from storj.http import Client
 
@@ -12,6 +14,9 @@ APP_NAME = 'storj'
 
 CFG_EMAIL = 'storj.email'
 CFG_PASSWORD = 'storj.password'
+
+
+__logger = logging.getLogger(__name__)
 
 
 def get_client():

--- a/tests/integration/bucket_test.py
+++ b/tests/integration/bucket_test.py
@@ -31,7 +31,7 @@ class Bucket(Integration):
         super(Bucket, self).tearDown()
         try:
             self.client.bucket_delete(self.bucket.id)
-        except MetadiskApiError as e:
+        except StorjBridgeApiError as e:
             self.logger.error(e)
 
     def test(self):
@@ -57,7 +57,7 @@ class Bucket(Integration):
         self.client.bucket_delete(self.bucket.id)
 
         self.logger.debug('2.1')
-        with pytest.raises(MetadiskApiError):
+        with pytest.raises(StorjBridgeApiError):
             self.client.bucket_get(self.bucket.id)
 
         self.logger.debug('2.2')

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Test cases for the storj.cli package."""
 
-import datetime
-
 import mock
+
+from datetime import datetime
 
 from click.testing import CliRunner
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -33,7 +33,7 @@ class FunctionsTestCase(AbstractTestCase):
         mock_read_config.assert_called_once_with()
 
     @mock.patch('storj.cli.click.get_app_dir')
-    @mock.patch('storj.cli.ConfigParser.RawConfigParser')
+    @mock.patch('storj.cli.configparser.RawConfigParser')
     def test_read_config(self, mock_class_rawconfigparser, mock_app_dir):
         # mock instance for ConfigParser.RawConfigParser
         mrcp = mock_class_rawconfigparser.return_value

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Test cases for the storj.cli package."""
+
+import datetime
+
+import mock
+
+from click.testing import CliRunner
+
+from storj import cli, http
+
+from .. import AbstractTestCase
+
+
+class FunctionsTestCase(AbstractTestCase):
+    """Test case for the package functions."""
+
+    @mock.patch.object(http.Client, '__init__')
+    @mock.patch('storj.cli.read_config', autospec=True)
+    def test_get_client(self, mock_read_config, mock_init):
+        mock_read_config.return_value = {
+            cli.CFG_EMAIL: 'someone@example.com',
+            cli.CFG_PASSWORD: 'secret'
+        }
+
+        assert cli.get_client() is not None
+
+        mock_read_config.assert_called_once_with()
+        mock_init.assert_called_once_with('someone@example.com', 'secret')
+
+    @mock.patch.object(cli.ConfigParser, 'RawConfigParser')
+    def test_read_config(self, mock_parser):
+        mock_parser.sections.return_value = {
+            'storj': {
+                'email': 'someone@example.com',
+                'password': 'secret'
+            }}
+
+        assert cli.read_config() == {
+            cli.CFG_EMAIL: 'someone@example.com',
+            cli.CFG_PASSWORD: 'secret'
+        }
+
+        mock_parser.sections.assert_called_once_with()
+
+
+class BucketTestCase(AbstractTestCase):
+    """Test case for bucket commands."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.test_id = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+
+    @mock.patch('storj.cli.Client.bucket_create', autospec=True)
+    def test_bucket_create(self, mock_action):
+        """Test create command."""
+        result = self.runner.invoke(cli.create, [self.test_id])
+
+        assert result.exit_code == 0
+        assert result.output == 'Hello Peter!\n'
+
+        mock_action.assert_called_once_with()
+
+    @mock.patch('storj.cli.Client.bucket_get', autospec=True)
+    def test_bucket_get(self, mock_action):
+        """Test get command."""
+        result = self.runner.invoke(cli.get, [self.test_id])
+
+        assert result.exit_code == 0
+        assert result.output == 'Hello Peter!\n'
+
+        mock_action.assert_called_once_with()
+
+    @mock.patch('storj.cli.Client.bucket_list', autospec=True)
+    def test_bucket_list(self, mock_action):
+        """Test list command."""
+        result = self.runner.invoke(cli.list, [])
+
+        assert result.exit_code == 0
+        assert result.output == 'Hello Peter!\n'
+
+        mock_action.assert_called_once_with()


### PR DESCRIPTION
- added `six` as 3rd party dependency
- fixed Python 3 incompatibility in the `storj.cli` package
- added tests for `storj.cli`
- minor output tweak for `storj-bucket get <id>`
- fixed exception name on integration tests

rejoice!