### PR TITLE
deploy from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,12 @@ after_success:
 notifications:
   slack: storjcommunity:TZfUO9ycY8R9UYwztWZTo0jk
   email: false
+
+deploy:
+  provider: pypi
+  user: super3
+  password:
+    secure: secret
+  on:
+    tags: true
+

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ help:
 	@echo "  test           Run tests."
 	@echo "  wheel          Build package wheel & save in $(WHEEL_DIR)."
 	@echo "  wheels         Build dependency wheels & save in $(WHEEL_DIR)."
-	@echo "  publish        Build and upload package to pypi.python.org"
 	@echo ""
 	@echo "VARIABLES:"
 	@echo "  PY_VERSION     Version of python to use. Default: $(PY_VERSION)"
@@ -93,10 +92,6 @@ test: setup
 	# report coverage
 	$(COVERAGE) html
 	$(COVERAGE) report  # --fail-under=90
-
-
-publish: test
-	$(PY) setup.py register bdist_wheel upload
 
 
 view_readme: setup


### PR DESCRIPTION
This PR allows travis-ci to automatically upload new tagged versions into pypi if the tag test build passes.

After merging this PR to master @super3 will need to use

`$ gem install travis && travis encrypt deploy.password`, edit `.travis.yml` and

replace the `secure: secret` with `secure: generated hash`.

`$ git add .travis.yml && git commit -m 'updated deploy password' && git push'`.

That should do it.
