### PR TITLE
move remaining functionality from Makefile to tox.ini and cleanup requirements-test.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 script:
   - tox -- --ignore=tests/integration
-  - "find ${TRAVIS_BUILD_DIR}/.tox -name log -type d | xargs -I {} rm -rf {}"
+  - "find ${HOME}/.pip -name log -type d | xargs -I {} rm -rf {}"
 
 after_success:
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ branches:
 
 cache:
   directories:
-    - "${HOME}/virtualenv"
-    - "${TRAVIS_BUILD_DIR}/.tox"
+    - "${HOME}/.pip"
 
 matrix:
   include:

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,6 @@ test: setup
 
 	# test
 	env/bin/tox -- --ignore=tests/integration
-	# $(COVERAGE) run --source=storj setup.py test
-
-	# report coverage
-	# $(COVERAGE) html
-	# $(COVERAGE) report  # --fail-under=90
 
 
 view_readme: setup

--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,7 @@ shell: install
 test: setup
 
 	# auto pep8 code
-	$(AUTOPEP8) --in-place --aggressive --aggressive --recursive storj
 	$(AUTOPEP8) --in-place --aggressive --aggressive --recursive examples
-	$(AUTOPEP8) --in-place --aggressive --aggressive --recursive tests
 
 	# ensure pep8
 	$(PEP8) examples

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,7 @@ test: setup
 	$(AUTOPEP8) --in-place --aggressive --aggressive --recursive tests
 
 	# ensure pep8
-	$(PEP8) storj
 	$(PEP8) examples
-	$(PEP8) tests
 
 	# test
 	env/bin/tox -- --ignore=tests/integration

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,5 @@
 autopep8
-coverage
 mock
-pep8
 pylint
 pytest
 pytest-cov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
-mock
-coverage
-coveralls
-pep8
 autopep8
+coverage
+mock
+pep8
 pylint
 pytest
 pytest-cov

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -34,7 +34,11 @@ def read_config():
     """Reads configuration for the command-line interface."""
 
     # OSX: /Users/<username>/Library/Application Support/storj
-    cfg = os.path.join(click.get_app_dir(APP_NAME, force_posix=True), 'storj.ini')
+    cfg = os.path.join(
+        click.get_app_dir(
+            APP_NAME,
+            force_posix=True),
+        'storj.ini')
 
     parser = configparser.RawConfigParser()
     parser.read([cfg])

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,12 @@ commands =
         --cov-report term-missing \
         --pep8 \
         {posargs}
-    autopep8 --in-place --aggressive --aggressive --recursive storj tests
+    autopep8 \
+        --in-place \
+        --aggressive \
+        --recursive \
+        --max-line-length 119 \
+        storj tests
     pep8 tests
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,8 @@ commands =
         --cov-report term-missing \
         --pep8 \
         {posargs}
+    autopep8 --in-place --aggressive --aggressive --recursive storj tests
     pep8 tests
-    autopep8 --in-place --aggressive --aggressive --recursive storj
-    autopep8 --in-place --aggressive --aggressive --recursive tests
 
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ commands =
         --pep8 \
         {posargs}
     pep8 tests
+    autopep8 --in-place --aggressive --aggressive --recursive storj
+    autopep8 --in-place --aggressive --aggressive --recursive tests
 
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
         --cov-report term-missing \
         --pep8 \
         {posargs}
+    pep8 tests
 
 
 [testenv:docs]


### PR DESCRIPTION
- cleanup Makefile
- `pep8` and `autopep8` checks done in `tox`
- updated test dependencies
  - no need for `coveralls`
  - `coverage` is already a dependency of `pytest-cov`
  - `pep8` is already a dependency of `pytest-pep8`
  - ordered dependencies alphabetically to easily spot duplicates