### PR TITLE
readthedocs missing API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-docs/apidoc
+docs/apidoc/
 log/
 t/
 tests/junit.xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -388,3 +388,8 @@ texinfo_documents = [(
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
+
+# Generate API doc
+from sphinx import apidoc
+
+apidoc.main(['-f', '-T', '--separate', '-o', 'apidoc', '../storj'])

--- a/storj/cli/__init__.py
+++ b/storj/cli/__init__.py
@@ -100,7 +100,7 @@ def get(bucket_id):
     bucket = get_client().bucket_get(bucket_id)
 
     for attr, value in sorted(bucket.__dict__.items()):
-        click.echo('%s : %s' % (attr.rjust(8), value))
+        click.echo('%s : %s' % (attr.rjust(18), value))
 
 
 @bucket.command()

--- a/storj/http.py
+++ b/storj/http.py
@@ -105,6 +105,16 @@ class Client(object):
             })
 
     def _prepare_request(self, **kwargs):
+        """Prepares a HTTP request.
+
+        Args:
+            kwargs (dict): keyword arguments for the authentication function
+                (``_add_ecdsa_signature()`` or ``_add_basic_auth()``) and
+                :py:class:`requests.Request` class.
+
+        Raises:
+            AssertionError: in case ``kwargs['path']`` doesn't start with ``/``.
+        """
 
         kwargs.setdefault('headers', {})
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -127,14 +127,16 @@ class BucketTestCase(AbstractTestCase):
 
         assert result.exit_code == 0
         assert result.output == '\n'.join([
-            ' created : %s' % self.bucket.created,
-            '      id : %s' % self.bucket.id,
-            '    name : %s' % self.bucket.name,
-            ' pubkeys : %s' % self.bucket.pubkeys,
-            '  status : %s' % self.bucket.status,
-            ' storage : %u' % self.bucket.storage,
-            'transfer : %u' % self.bucket.transfer,
-            '    user : %s\n' % self.bucket.user,
+            '           created : %s' % self.bucket.created,
+            '     encryptionKey : %s' % self.bucket.encryptionKey,
+            '                id : %s' % self.bucket.id,
+            '              name : %s' % self.bucket.name,
+            '           pubkeys : %s' % self.bucket.pubkeys,
+            ' publicPermissions : %s' % self.bucket.publicPermissions,
+            '            status : %s' % self.bucket.status,
+            '           storage : %u' % self.bucket.storage,
+            '          transfer : %u' % self.bucket.transfer,
+            '              user : %s\n' % self.bucket.user,
         ])
 
         self.mock_action.assert_called_once_with(self.bucket.id)

--- a/tox.ini
+++ b/tox.ini
@@ -42,11 +42,11 @@ commands =
 
 [testenv:docs]
 changedir = docs
+usedevelop = False
 deps = -rrequirements-docs.txt
 
 commands =
     make dummy
-    make apidoc
     make coverage
     make changes
     make html


### PR DESCRIPTION
- today I discovered I can use the `docs/conf.py` file to automatically generate the API documentation https://github.com/rtfd/readthedocs.org/issues/1139
- added a docstring comment as well