### PR TITLE
tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,29 +14,20 @@ before_cache:
 matrix:
   include:
     - python: 3.6
-      env: TOXENV=py36
     - python: 3.5
-      env: TOXENV=py35
     - python: 3.4
-      env: TOXENV=py34
     - python: 3.3
-      env: TOXENV=py33
     - python: 2.7
-      env: TOXENV=py27
     - python: pypy
-      env: TOXENV=pypy
   allow_failures:
     - python: 3.6
-      env: TOXENV=py36
     - python: 3.5
-      env: TOXENV=py35
     - python: 3.4
-      env: TOXENV=py34
     - python: 3.3
-      env: TOXENV=py33
 
 install:
   - pip install tox
+  - pip install tox-travis
 
 script:
   - tox -- --ignore=tests/integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   directories:
     - "${HOME}/.pip"
 
+before_cache:
+  - "find ${HOME}/.pip -name log -o -name __pycache__ -type d | xargs -I {} rm -rf {}"
+
 matrix:
   include:
     - python: 3.6
@@ -37,7 +40,6 @@ install:
 
 script:
   - tox -- --ignore=tests/integration
-  - "find ${HOME}/.pip -name log -type d | xargs -I {} rm -rf {}"
 
 after_success:
   - pip install coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -62,3 +62,4 @@ whitelist_externals =
 3.4 = py34
 3.3 = py33
 2.7 = py27
+pypy = pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py2{7}
-    pypy
+    py3{6}
 
 
 [pytest]
@@ -40,6 +40,7 @@ commands =
         --ignore=W503 \
         tests
 
+
 [testenv:docs]
 changedir = docs
 usedevelop = False
@@ -53,3 +54,11 @@ commands =
 
 whitelist_externals =
     /usr/bin/make
+
+
+[tox:travis]
+3.6 = py36
+3.5 = py35
+3.4 = py34
+3.3 = py33
+2.7 = py27


### PR DESCRIPTION
- use `tox-travis`
- cleanup `.travis.yml`
- by default test against the latest minor version of each Python major version (`2.7` and `3.6`)
