### PR TITLE
Fix misplacement of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ ENV/
 pyvenv.cfg
 .venv
 pip-selfcheck.json
+
+# Keys
+*.pem

--- a/storj/__init__.py
+++ b/storj/__init__.py
@@ -7,8 +7,6 @@ import io
 from abc import ABCMeta
 from hashlib import sha256
 
-from ecdsa import SigningKey, SECP256k1
-
 from .api import ecdsa_to_hex
 from .configuration import read_config
 from .http import Client
@@ -23,24 +21,6 @@ def get_client():
         (:py:class:`storj.http.Client`): Storj HTTP client.
     """
     return Client(*read_config())
-
-
-def generate_new_key_pair():
-    """
-    Generate a new key pair.
-
-    Returns:
-        tuple(:py:class:`ecdsa.keys.SigningKey`,
-              :py:class:`ecdsa.keys.VerifyingKey`):
-        key pair (private, public).
-    """
-
-    private_key = SigningKey.generate(
-        curve=SECP256k1,
-        hashfunc=sha256,
-    )
-
-    return private_key, private_key.get_verifying_key()
 
 
 class BucketManager(ABCMeta):

--- a/storj/http.py
+++ b/storj/http.py
@@ -11,6 +11,7 @@ import time
 from base64 import b64encode
 from binascii import b2a_hex
 from ecdsa import SigningKey, SECP256k1, VerifyingKey
+from ecdsa.util import sigencode_der
 from hashlib import sha256
 from io import BytesIO
 from six.moves.urllib.parse import urlencode, urljoin
@@ -65,7 +66,7 @@ class Client(object):
         if isinstance(ecdsa_private_key, SigningKey):
             self.private_key = ecdsa_private_key
             self.public_key = self.private_key.get_verifying_key()
-            self.public_key_hex = ecdsa_to_hex(self.public_key)
+            self.public_key_hex = ecdsa_to_hex(self.public_key.to_string())
 
     def _add_basic_auth(self, request_kwargs):
         self.logger.debug('using basic auth')
@@ -100,7 +101,7 @@ class Client(object):
         request_kwargs['headers'].update(
             {
                 'x-signature': signature,
-                'x-pubkey': ecdsa_to_hex(self.public_key),
+                'x-pubkey': ecdsa_to_hex(self.public_key.to_string()),
             })
 
     def _prepare_request(self, **kwargs):
@@ -668,7 +669,7 @@ class Client(object):
         self._request(
             method='POST',
             path='/keys',
-            json={'key': ecdsa_to_hex(public_key)})
+            json={'key': ecdsa_to_hex(public_key.to_string())})
 
     def token_create(self, bucket_id, operation):
         """Creates a token for the specified operation.

--- a/storj/http.py
+++ b/storj/http.py
@@ -610,28 +610,17 @@ class Client(object):
 
     def key_generate(self):
 
-        def generate_new_key_pair():
-            """
-            Generate a new key pair.
-
-            Returns:
-                tuple(:py:class:`ecdsa.keys.SigningKey`,
-                      :py:class:`ecdsa.keys.VerifyingKey`):
-                key pair (private, public).
-            """
-
-            private_key = SigningKey.generate(
-                curve=SECP256k1,
-                hashfunc=sha256,
-            )
-
-            return private_key, private_key.get_verifying_key()
-
         self.logger.info('key_generate()')
 
         print("This will replace your public and private keys in 3 seconds...")
         time.sleep(3)
-        (self.private_key, self.public_key) = generate_new_key_pair()
+
+        self.private_key = SigningKey.generate(
+                curve=SECP256k1,
+                hashfunc=sha256,
+        )
+
+        self.public_key = self.private_key.get_verifying_key()
 
         s = raw_input('Export keys to file for later use? [Y/N]')
         if 'Y' in s.upper():


### PR DESCRIPTION
There is no  reason to place  `generate_new_key_pair`  function in `__init__.py` file.
It also raises an exception if someone imports `http.Client` class.