### PR TITLE
Fix file separator errors

### DIFF
--- a/storj/model.py
+++ b/storj/model.py
@@ -820,13 +820,13 @@ class ShardManager(Object):
             if self.tmp_path is None:
                 if platform == 'linux' or platform == 'linux2':
                     # linux
-                    self.tmp_path = '/tmp/'
+                    self.tmp_path = '/tmp'
                 elif platform == 'darwin':
                     # OS X
-                    self.tmp_path = '/tmp/'
+                    self.tmp_path = '/tmp'
                 elif platform == 'win32':
                     # Windows
-                    self.tmp_path = 'C://Windows/temp/'
+                    self.tmp_path = 'C://Windows/temp'
             self.__logger.debug('self.tmp_path=%s', self.tmp_path)
 
             try:
@@ -835,7 +835,8 @@ class ShardManager(Object):
                 total_bytes += len(data)
                 inc = len(data)
 
-                with open('%s/%s' % (self.tmp_path, chunkfilename), 'wb') as chunkf:
+                with open(os.path.join(self.tmp_path, chunkfilename),
+                          'wb') as chunkf:
                     chunkf.write(data)
 
                 challenges = self._make_challenges(self.nchallenges)

--- a/storj/model.py
+++ b/storj/model.py
@@ -10,7 +10,6 @@ import math
 import io
 import random
 import os
-import os.path
 
 import six
 import strict_rfc3339


### PR DESCRIPTION
I had a double separator between the temp dir path and the name of the file. This commit fixes the problem.
Moreover, it's better to avoid keeping folder without the `/` at the end (imho), and use `os.path.join` to create path instead of `%s/%s`