### PR TITLE
Implement multiprocessing in file upload

### DIFF
--- a/storj/uploader.py
+++ b/storj/uploader.py
@@ -402,4 +402,3 @@ staging frame')
         if encryption_enabled and file_path_ready:
             self.__logger.debug('Remove file %s', file_path_ready)
             os.remove('%s*' % file_path_ready)
-

--- a/storj/uploader.py
+++ b/storj/uploader.py
@@ -339,8 +339,8 @@ staging frame')
         # Now generate shards
         self.__logger.debug('Sharding started...')
         shards_manager = model.ShardManager(filepath=file_path_ready,
-                                            tmp_path=self.tmp_path)
-        self.all_shards_count = len(shards_manager.num_shards)
+                                            tmp_path=tmp_file_path)
+        self.all_shards_count = shards_manager.index
 
         self.__logger.debug('Sharding ended...')
 


### PR DESCRIPTION
Use a Pool for uploading shards, instead of launching single threads every time (consistency with the downloader).
For uploading a file, use the method `file_upload` instead of `createNewUploadThread` (more user friendly).
Some class variables have been deleted (e.g., the bucket id.. keeping it as a class variable has no sense)