### PR TITLE
Implement timeout for download from slow farmers

### DIFF
--- a/storj/downloader.py
+++ b/storj/downloader.py
@@ -96,7 +96,7 @@ class Downloader:
                         'There are %s shard pointers: ', len(shard_pointers))
 
                     # Calculate timeout
-                    self._calculate_timeout(shard_pointers[0]['size'], mbps=20)
+                    self._calculate_timeout(shard_pointers[0]['size'], mbps=1)
 
                     # Upload shards thread pool
                     self.__logger.debug('Begin shards download process')

--- a/storj/downloader.py
+++ b/storj/downloader.py
@@ -24,30 +24,6 @@ MAX_RETRIES_DOWNLOAD_FROM_SAME_FARMER = 3
 MAX_RETRIES_GET_FILE_POINTERS = 10
 
 
-def quit_function(fn_name):
-    # self.__logger.debug('{0} took too long'.format(fn_name))
-    thread.interrupt_main()  # raises KeyboardInterrupt
-
-
-def exit_after(s):
-    '''
-    use as decorator to exit process if
-    function takes longer than s seconds
-    '''
-    def outer(fn):
-        def inner(*args, **kwargs):
-            timer = threading.Timer(s, quit_function, args=[fn.__name__])
-            timer.start()
-            try:
-                result = fn(*args, **kwargs)
-            finally:
-                timer.cancel()
-            return result
-        return inner
-
-    return outer
-
-
 class Downloader:
 
     __logger = logging.getLogger('%s.ClassName' % __name__)
@@ -203,7 +179,6 @@ class Downloader:
 
         return True
 
-    # @exit_after(TIMEOUT)
     def retrieve_shard_file(self, url, shard_index):
         farmer_tries = 0
 

--- a/storj/downloader.py
+++ b/storj/downloader.py
@@ -73,7 +73,8 @@ class Downloader:
 
         try:
             self.__logger.debug(
-                'Resolving file pointers to download file with ID: %s ...', file_id)
+                'Resolving file pointers to download file with ID: %s ...',
+                file_id)
 
             tries_get_file_pointers = 0
 
@@ -108,9 +109,8 @@ class Downloader:
                 except StorjBridgeApiError as e:
                     self.__logger.error(e)
                     self.__logger.error('Bridge error')
-                    self.__logger.error(
-                        'Error while resolving file pointers to download file with ID: %s ...',
-                        file_id)
+                    self.__logger.error('Error while resolving file pointers \
+to download file with ID: %s ...', file_id)
                     self.__logger.error(e)
                     continue
                 else:
@@ -120,7 +120,7 @@ class Downloader:
             self.__logger.error(e)
             self.__logger.error("Outern Bridge error")
             self.__logger.error("Error while resolving file pointers to \
-                download file with ID: %s" % str(file_id))
+download file with ID: %s" % str(file_id))
 
         # All the shards have been downloaded
         self.__logger.debug(shards)
@@ -135,7 +135,8 @@ class Downloader:
         sharding_tools = ShardingTools()
         self.__logger.debug('Joining shards...')
 
-        destination_path = os.path.join(self.destination_file_path, self.filename_from_bridge)
+        destination_path = os.path.join(self.destination_file_path,
+                                        self.filename_from_bridge)
         self.__logger.debug('Destination path %s', destination_path)
 
         try:
@@ -210,14 +211,17 @@ class Downloader:
 
             except StorjFarmerError as e:
                 self.__logger.error(e)
+                # Update shard download state
                 self.__logger.error("First try failed. Retrying... (%s)" %
-                                    str(farmer_tries))  # update shard download state
+                                    str(farmer_tries))
 
             except Exception as e:
                 self.__logger.error(e)
                 self.__logger.error("Unhandled error")
                 self.__logger.error("Error occured while downloading shard at "
-                                    "index %s. Retrying... (%s)" % (shard_index, farmer_tries))
+                                    "index %s. Retrying... (%s)" %
+                                    (shard_index,
+                                     farmer_tries))
 
         self.__logger.error("Shard download at index %s failed" % shard_index)
         raise ClientError()
@@ -227,7 +231,8 @@ class Downloader:
 
         try:
             self.__logger.debug('Starting download threads...')
-            self.__logger.debug('Downloading shard at index %s ...', shard_index)
+            self.__logger.debug('Downloading shard at index %s ...',
+                                shard_index)
 
             url = 'http://{address}:{port}/shards/{hash}?token={token}'.format(
                 address=pointer.get('farmer')['address'],
@@ -244,7 +249,8 @@ class Downloader:
 
             # shard = self.retrieve_shard_file(url, shard_index)
             self.__logger.debug('Shard downloaded')
-            self.__logger.debug('Shard at index %s downloaded successfully', shard_index)
+            self.__logger.debug('Shard at index %s downloaded successfully',
+                                shard_index)
             return shard
 
         except IOError as e:


### PR DESCRIPTION
If a farmer is slow (default: `<1mbps`), a new pointer is got and a new download for that shard is tried