### PR TITLE
Fix shardmanager at upload

### DIFF
--- a/storj/downloader.py
+++ b/storj/downloader.py
@@ -120,9 +120,9 @@ to download file with ID: %s ...', file_id)
 
         except StorjBridgeApiError as e:
             self.__logger.error(e)
-            self.__logger.error("Outern Bridge error")
-            self.__logger.error("Error while resolving file pointers to \
-download file with ID: %s" % str(file_id))
+            self.__logger.error('Outern Bridge error')
+            self.__logger.error('Error while resolving file pointers to \
+download file with ID: %s' % str(file_id))
 
         # All the shards have been downloaded
         self.__logger.debug(shards)
@@ -214,7 +214,7 @@ download file with ID: %s" % str(file_id))
             except StorjFarmerError as e:
                 self.__logger.error(e)
                 # Update shard download state
-                self.__logger.error("First try failed. Retrying... (%s)" %
+                self.__logger.error('First try failed. Retrying... (%s)' %
                                     str(farmer_tries))
 
             except requests.exceptions.Timeout as ret:
@@ -224,13 +224,13 @@ Took too much.' % (farmer_tries, shard_index))
 
             except Exception as e:
                 self.__logger.error(e)
-                self.__logger.error("Unhandled error")
-                self.__logger.error("Error occured while downloading shard at "
-                                    "index %s. Retrying... (%s)" %
+                self.__logger.error('Unhandled error')
+                self.__logger.error('Error occured while downloading shard at '
+                                    'index %s. Retrying... (%s)' %
                                     (shard_index,
                                      farmer_tries))
 
-        self.__logger.error("Shard download at index %s failed" % shard_index)
+        self.__logger.error('Shard download at index %s failed' % shard_index)
         raise ClientError()
 
     def shard_download(self, pointer, shard_index, bucket_id, file_id):

--- a/storj/model.py
+++ b/storj/model.py
@@ -670,10 +670,10 @@ class ShardManager(Object):
     SHARD_MULTIPLES_BACK = 4
     SHARD_SIZE = 8 * (1024 * 1024)  # 8Mb
 
-    def __init__(self, filepath, shard_size=None, tmp_path=None, nchallenges=2, suffix=''):
-        self.num_chunks = 0
+    def __init__(self, filepath, num_chunks=0, tmp_path=None, nchallenges=2, suffix=''):
+        self.num_chunks = num_chunks
         self.nchallenges = nchallenges
-        self.shard_size = shard_size
+        self.shard_size = 0
         self.shards = []
         self.suffix = suffix
         self.tmp_path = tmp_path
@@ -739,11 +739,16 @@ class ShardManager(Object):
             tuple[long, int]: shard size, number of shards.
         """
 
-        shard_size = self.determine_shard_size()
-        if shard_size == 0:
-            shard_size = self.filesize
+        if self.num_chunks != 0:
+            self.__logger.debug('Number of shards already set')
+            shard_count = self.num_chunks
+            shard_size = int(math.ceil(float(self.filesize) / float(shard_count)))
+        else:
+            shard_size = self.determine_shard_size()
+            if shard_size == 0:
+                shard_size = self.filesize
 
-        shard_count = int(math.ceil(float(self.filesize) / float(shard_size)))
+            shard_count = int(math.ceil(float(self.filesize) / float(shard_size)))
 
         self.__logger.debug(
             'shard_size = %d, shard_count = %d, file_size = %d',

--- a/storj/model.py
+++ b/storj/model.py
@@ -657,7 +657,6 @@ class ShardManager(Object):
     Attributes:
         tmp_path (str): directory where the chunk files will reside.
         nchallenges : number of challenges.
-        shard_size (): .
         shards (list[]): shards.
         filepath (str): path to the original file.
         num_chunks (int): number of chunks used to split the file.
@@ -673,7 +672,6 @@ class ShardManager(Object):
     def __init__(self, filepath, num_chunks=0, tmp_path=None, nchallenges=2, suffix=''):
         self.num_chunks = num_chunks
         self.nchallenges = nchallenges
-        self.shard_size = 0
         self.shards = []
         self.suffix = suffix
         self.tmp_path = tmp_path
@@ -729,7 +727,7 @@ class ShardManager(Object):
 
         self.__logger.debug('self.tmp_path=%s', self._tmp_path)
 
-    def get_optimal_shard_parameters(self):
+    def get_optimal_shard_number(self):
         """
         Returns the optimal sharding parameters.
 
@@ -739,22 +737,17 @@ class ShardManager(Object):
             tuple[long, int]: shard size, number of shards.
         """
 
-        if self.num_chunks != 0:
-            self.__logger.debug('Number of shards already set')
-            shard_count = self.num_chunks
-            shard_size = int(math.ceil(float(self.filesize) / float(shard_count)))
-        else:
-            shard_size = self.determine_shard_size()
-            if shard_size == 0:
-                shard_size = self.filesize
+        shard_size = self.determine_shard_size()
+        if shard_size == 0:
+            shard_size = self.filesize
 
-            shard_count = int(math.ceil(float(self.filesize) / float(shard_size)))
+        shard_count = int(math.ceil(float(self.filesize) / float(shard_size)))
 
         self.__logger.debug(
             'shard_size = %d, shard_count = %d, file_size = %d',
             shard_size, shard_count, self.filesize)
 
-        return shard_size, shard_count
+        return shard_count
 
     def determine_shard_size(self, accumulator=0):
         """
@@ -806,7 +799,8 @@ class ShardManager(Object):
     def _make_shards(self):
         """Populates the shard manager with shards."""
 
-        self.shard_size, self.num_chunks = self.get_optimal_shard_parameters()
+        if self.num_chunks == 0
+            self.num_chunks = self.get_optimal_shard_number()
         self.__logger.debug('number of chunks %d', self.num_chunks)
 
         index = 0

--- a/storj/model.py
+++ b/storj/model.py
@@ -729,12 +729,12 @@ class ShardManager(Object):
 
     def get_optimal_shard_number(self):
         """
-        Returns the optimal sharding parameters.
+        Returns the optimal number of shards.
 
         See https://github.com/aleitner/shard-size-calculator/blob/master/src/shard_size.c
 
         Returns:
-            tuple[long, int]: shard size, number of shards.
+            [int]: number of shards.
         """
 
         shard_size = self.determine_shard_size()
@@ -751,6 +751,7 @@ class ShardManager(Object):
 
     def determine_shard_size(self, accumulator=0):
         """
+        Determine the optimal shard size.
 
         See https://github.com/aleitner/shard-size-calculator/blob/master/src/shard_size.c
 

--- a/storj/model.py
+++ b/storj/model.py
@@ -799,7 +799,7 @@ class ShardManager(Object):
     def _make_shards(self):
         """Populates the shard manager with shards."""
 
-        if self.num_chunks == 0
+        if self.num_chunks == 0:
             self.num_chunks = self.get_optimal_shard_number()
         self.__logger.debug('number of chunks %d', self.num_chunks)
 

--- a/tests/unit/model_test.py
+++ b/tests/unit/model_test.py
@@ -415,8 +415,8 @@ class ShardManagerTestCase(AbstractTestCase):
         mock_tree.reset_mock()
         mock_challenges.reset_mock()
 
-    def test_get_optimal_shard_parameters(self):
-        """Test ShardManager.get_optimal_shard_parameters()."""
+    def test_get_optimal_shard_number(self):
+        """Test ShardManager.get_optimal_shard_number()."""
         shard_manager = ShardManager(__file__)
 
         for file_size, expected_shard_size, expected_shard_count in [
@@ -424,10 +424,9 @@ class ShardManagerTestCase(AbstractTestCase):
             (43 * self.GB, 4 * self.GB, 11)
         ]:
             shard_manager._filesize = file_size
-            shard_size, shard_count = \
-                shard_manager.get_optimal_shard_parameters()
+            shard_count = \
+                shard_manager.get_optimal_shard_number()
 
-            assert expected_shard_size == shard_size
             assert expected_shard_count == shard_count
 
     @mock.patch.object(ShardManager, '_sha256')


### PR DESCRIPTION
I propose the following changes in class `ShardManager`:
- let the user define the number of shards and not the dimension of the shards (I think it is more "user friendly")
- if the user defines the number of shards (parameter `num_chunks`), use it! In fact, at the current version, we let the user specify the shard dimension but this parameter is not taken into consideration.
- Function `get_optimal_shard_parameters` returns the number of shards and their dimension, but the dimension is not used. So I propose to change it into `get_optimal_shard_number` since what we use is only the number of shards